### PR TITLE
Source map boondoggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,12 @@
     "tape": "^3.0.1",
     "watchify": "^2.1.0"
   },
+  "browser": {
+    "btoa": false
+  },
   "dependencies": {
     "acorn": "^0.11.0",
+    "btoa": "^1.1.2",
     "escodegen": "^1.4.3",
     "esprima": "^1.2.2",
     "smokestack": "^3.0.0",


### PR DESCRIPTION
To get line numbers for errors, I really want source maps to work but either
- The JS has to be external to the page, which might / might not be possible (Blobs?)
- or I use a script tag in a `<script>foo</script>`-style JS chunk
